### PR TITLE
feat(pipes): create `startsWith()`

### DIFF
--- a/pipes/startsWith.test.ts
+++ b/pipes/startsWith.test.ts
@@ -1,0 +1,34 @@
+import { assertEquals, assertIsError } from "std/assert/mod.ts";
+import { pipe, string } from "../schemas/mod.ts";
+import { SchemaContext } from "../context.ts";
+import { startsWith } from "./startsWith.ts";
+
+const context: SchemaContext = { path: [] };
+
+Deno.test("starts with the specified search", () => {
+  const schema = pipe(string(), startsWith("abc"));
+
+  const correct = [
+    `abc`,
+    `abc123`,
+    `abcd`,
+    `abcd123`,
+  ];
+
+  const incorrect = [
+    ``,
+    `ab`,
+    `ac`,
+    `abC`,
+    `ABC`,
+    `a1234`,
+  ];
+
+  for (const example of correct) {
+    assertEquals(schema.check(example, context), example);
+  }
+
+  for (const example of incorrect) {
+    assertIsError(schema.check(example, context));
+  }
+});

--- a/pipes/startsWith.ts
+++ b/pipes/startsWith.ts
@@ -1,0 +1,21 @@
+import { SchemaContext } from "../context.ts";
+import { createError } from "../errors.ts";
+
+/**
+ * Check the `value` starts with `search`.
+ * @example ```ts
+ * const CodeSchema = pipe(string(), startsWith("CODE-"));
+ * ```
+ */
+export function startsWith(
+  search: string,
+  message = `Must start with "${search}"`,
+) {
+  return function (value: string, context: SchemaContext) {
+    if (value.startsWith(search)) {
+      return value;
+    }
+
+    return createError(context, { message });
+  };
+}


### PR DESCRIPTION
Creates the `startsWith()` step for `string()` schema.